### PR TITLE
Add JSON syntax highlighting to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ try serializer.serialize(users)
 ```
 
 ### Produces
-```
+```js
 {
   "data": [{
     "type": "users",
@@ -70,7 +70,7 @@ try serializer.serialize(users)
 ```
 
 ### Produces
-```
+```js
 {
   "data": [
     {


### PR DESCRIPTION
I tried using `json` as the language tag, but it doesn't highlight the colons, while `js` does.